### PR TITLE
Enable fact gathering in playbook.yml

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -3,7 +3,7 @@
   hosts:
     - all
     - localhost
-  gather_facts: false
+  gather_facts: true
   vars: {}
   roles:
     - role: uusrc.general.uv


### PR DESCRIPTION
Tests are failing with the following error message:

```
The conditional check 'ansible_pkg_mgr == 'apt'' failed. The error was: error while evaluating conditional (ansible_pkg_mgr == 'apt'): 'ansible_pkg_mgr' is undefined. 
```

`ansible_pkg_mgr` is a fact (variable) that is available only when Ansible is configured to '[gather facts](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/gather_facts_module.html)' before a playbook is executed. However, the playbook had disabled fact gathering. Fix this to see where CI will fail next. :)