### PR TITLE
Fix nginx reverse proxy configuration

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -19,8 +19,9 @@
     - role: openwebui
     - role: uusrc.general.nginx_reverse_proxy
       vars:
-        location: /
-        auth: sram
-        proxy_pass: http://localhost:3000
-        proxy_set_header: X-Remote-User-Mail $username@localhost
-
+        nginx_reverse_proxy_locations:
+          - name: openwebui
+            location: /
+            auth: sram
+            proxy_pass: http://localhost:3000
+            # proxy_set_header: "X-Remote-User-Mail $username@localhost"


### PR DESCRIPTION
I passed in the wrong parameters to the `uusrc.general.nginx_reverse_proxy`. Fix as per the documentation:

https://utrechtuniversity.github.io/researchcloud-items/playbooks/reverse_proxy.html