### PR TITLE
Change default expose_api value to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The component takes the following parameters:
 * `model`: String. A default Ollama model to pull at workspace creation (you can pull more models yourself after the workspace is running). Leave empty for none.
 * `ollama_version`: String. Version of Ollama to install, e.g. `0.17.7`. Leave empty for latest version.
 * `ollama_use_external_storage`: Boolean (default: `true`). In case this is true, and in case an SRC Storage Unit is attached to the workspace, will use that storage unit to store Ollama data (including models). This allows pulling larger models than fit on the workspace's internal storage.
-* `expose_api`: Boolean (default: `true`). Whether the reverse proxy should serve Open WebUI's API at the route `http://<workspace_name>/ext/api`. This will let through traffic to Open WebUI's API without SRAM authentication, allowing you to use the API from outside of the workspace for automated worklows.
+* `expose_api`: Boolean (default: `false`). Whether the reverse proxy should serve Open WebUI's API at the route `http://<workspace_name>/ext/api`. This will let through traffic to Open WebUI's API without SRAM authentication, allowing you to use the API from outside of the workspace for automated worklows.
 
 ## Maintenance
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -27,7 +27,7 @@
               X-Remote-User-Mail: $username@localhost
           - name: api
             location: /ext/api/ # serve the api under a special route to connect to it directly (instead of via the UI)
-            auth: "{{ expose_api | default(true, true) | bool | ternary('noauth', 'sram') }}"
+            auth: "{{ expose_api | default(false, true) | bool | ternary('noauth', 'sram') }}"
             proxy_pass: http://localhost:8080/api/
             proxy_set_header:
               X-Remote-User-Mail: '""' # ensure outside clients cannot set a trusted header


### PR DESCRIPTION
@jelletreep I'm thinking that since exposing the API is a slight security concern, this should be disabled by default. What do you think?