### PR TITLE
Add API exposure and user access configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can request access to a catalog item that utilises this component [here](htt
 * [Ollama](https://ollama.com/) runs as a model backend on `http://localhost:3000`.
 * Open WebUI runs on `http://localhost:3000`.
 * Nginx reverse proxies inbound https to Open WebUI.
-  * If desired, the API is also reverse proxied under `http://<workspace_name>/ext/api`, allowing you to bypass SRAM authentication and use API keys to connect directly to the API.
+  * If desired, the [API](#API) can be reverse proxied at `http://<workspace_name>/ext/api`, allowing you to bypass SRAM authentication and use API keys to connect directly to the API.
 
 ### Authentication
 
@@ -28,7 +28,21 @@ Any members of the workspace's Collaborative Organisation (CO) will be able to a
 
 If desired, the Open WebUI [API](https://docs.openwebui.com/reference/monitoring/) is exposed by Nginx, without SRAM authentication. To do this, set the `expose_api` [parameter](#ResearchCloud-parameters) to `true`.
 
-If the API is enabled, then by default, **both normal users and admin users can use the API**. They will still need to [set API keys for your user in Open WebUI](https://docs.openwebui.com/features/authentication-access/api-keys/#step-3-generate-a-key), and use them when making requests. To allow **only admin users to use the API**, set the `normal_users_api_access` parameter to `false`.
+**Note**: the API is not served at the default `/api`, but at `/ext/api`. This is so that the normal `/api` route continues to work with SRAM auth, which is needed by the Open WebUI frontend.
+
+## API Authorization
+
+If the API is enabled, then by default, **both normal users and admin users can use the API**.
+
+Every use will need to [create an API keys in Open WebUI](https://docs.openwebui.com/features/authentication-access/api-keys/#step-3-generate-a-key), and use it when making requests.
+
+To allow **only admin users to use the API**, set the `normal_users_api_access` [parameter](#researchcloud-parameters) to `false`.
+
+## Additional API security
+
+By default, requests to `/ext/api` will be immediately proxied to Open WebUI---that is, without, any authentication layer in the webserver. However, Open WebUI still requires users to create API keys, and you will have to use these with your requests.
+
+If you want to add a layer of security, you can set the `api_credentials_secret` [parameter](#researchcloud-parameters) to add HTTP Basic Authentication to the API. Your requests will have to be made with the correct HTTP username/password headers, in addition to using the Open WebUI API keys.
 
 ## ResearchCloud parameters
 
@@ -38,6 +52,8 @@ The component takes the following parameters:
 * `ollama_version`: String. Version of Ollama to install, e.g. `0.17.7`. Leave empty for latest version.
 * `ollama_use_external_storage`: Boolean (default: `true`). In case this is true, and in case an SRC Storage Unit is attached to the workspace, will use that storage unit to store Ollama data (including models). This allows pulling larger models than fit on the workspace's internal storage.
 * `expose_api`: Boolean (default: `true`). Whether the reverse proxy should serve Open WebUI's API at the route `http://<workspace_name>/ext/api`. This will let through traffic to Open WebUI's API without SRAM authentication, allowing you to use the API from outside of the workspace for automated worklows.
+* `api_credentials_secret`: String. Username and password for HTTP Basic Authentication for the `/ext/api` route. Username and password should be separated by a space, e.g. `foo bar`. *Tip*: you can set this using a CO Secret in ResearchCloud.
+* `normal_users_api_access`: Boolean. Whether non-admin users should be allowed to use the API as well. Default: `true`. *Note*: at the moment all users that login via SRAM are considered admin users, so this parameter is not yet effective (see issue #19). 
 
 ## Maintenance
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ The server is configured to let the webserver (Nginx) handle authentication. The
 
 Any members of the workspace's Collaborative Organisation (CO) will be able to authenticate using the authentication mechanism of their institution (Single Sign-On). At the moment all members of the collaboration will be considered admins for Open WebUI. Support for finer-grained access management via SRAM is tracked [here](https://github.com/UtrechtUniversity/src-component-openwebui/issues/19).
 
-If desired, the Open WebUI [API](https://docs.openwebui.com/reference/monitoring/) is exposed by Nginx, without SRAM authentication (see [parameters](#ResearchCloud-parameters) below). You'll need to set API keys for your user in Open WebUI, and use them when making requests.
+# API
+
+If desired, the Open WebUI [API](https://docs.openwebui.com/reference/monitoring/) is exposed by Nginx, without SRAM authentication. To do this, set the `expose_api` [parameter](#ResearchCloud-parameters) to `true`.
+
+If the API is enabled, then by default, **both normal users and admin users can use the API**. They will still need to [set API keys for your user in Open WebUI](https://docs.openwebui.com/features/authentication-access/api-keys/#step-3-generate-a-key), and use them when making requests. To allow **only admin users to use the API**, set the `normal_users_api_access` parameter to `false`.
 
 ## ResearchCloud parameters
 

--- a/playbook.yml
+++ b/playbook.yml
@@ -6,6 +6,7 @@
     _fqdn: "{{ workspace_fqdn | default('localhost:8080') }}" # workspace_fqdn is a special component parameter defined in SRC
     _openwebui_url: "{{ _fqdn is match 'localhost:' | ternary('http://', 'https://') }}{{ _fqdn }}"
     _expose_api: "{{ expose_api | default(true, true) | bool }}"
+    _normal_users_api_access: "{{ normal_users_api_access | default(true, true) | bool }}"
   gather_facts: true
   roles:
     - role: ollama-serve
@@ -18,7 +19,7 @@
         openwebui_url: "{{ _openwebui_url }}"
         openwebui_port: 8080
         openwebui_expose_api: "{{ _expose_api }}"
-        openwebui_user_access_api: "{{ normal_users_api_access }}"
+        openwebui_user_access_api: "{{ _normal_users_api_access }}"
     - role: uusrc.general.nginx_reverse_proxy
       vars:
         nginx_reverse_proxy_locations:

--- a/playbook.yml
+++ b/playbook.yml
@@ -5,6 +5,7 @@
   vars:
     _fqdn: "{{ workspace_fqdn | default('localhost:8080') }}" # workspace_fqdn is a special component parameter defined in SRC
     _openwebui_url: "{{ _fqdn is match 'localhost:' | ternary('http://', 'https://') }}{{ _fqdn }}"
+    _expose_api: "{{ expose_api | default(true, true) | bool }}"
   gather_facts: true
   roles:
     - role: ollama-serve
@@ -16,6 +17,8 @@
       vars:
         openwebui_url: "{{ _openwebui_url }}"
         openwebui_port: 8080
+        openwebui_expose_api: "{{ _expose_api }}"
+        openwebui_user_access_api: "{{ normal_users_api_access }}"
     - role: uusrc.general.nginx_reverse_proxy
       vars:
         nginx_reverse_proxy_locations:
@@ -27,7 +30,7 @@
               X-Remote-User-Mail: $username@localhost
           - name: api
             location: /ext/api/ # serve the api under a special route to connect to it directly (instead of via the UI)
-            auth: "{{ expose_api | default(true, true) | bool | ternary('noauth', 'sram') }}"
+            auth: "{{ _expose_api | ternary('noauth', 'sram') }}"
             proxy_pass: http://localhost:8080/api/
             proxy_set_header:
               X-Remote-User-Mail: '""' # ensure outside clients cannot set a trusted header

--- a/playbook.yml
+++ b/playbook.yml
@@ -37,16 +37,11 @@
         openwebui_user_access_api: "{{ _normal_users_api_access }}"
     - role: uusrc.general.nginx_reverse_proxy
       vars:
-        nginx_reverse_proxy_locations:
-          - name: openwebui
-            location: /
-            auth: sram
-            proxy_pass: http://localhost:8080
-            proxy_set_header:
-              X-Remote-User-Mail: $username@localhost
-          - name: api
-            location: /ext/api/ # serve the api under a special route to connect to it directly (instead of via the UI)
-            auth: "{{ _expose_api | ternary('noauth', 'sram') }}"
-            proxy_pass: http://localhost:8080/api/
-            proxy_set_header:
-              X-Remote-User-Mail: '""' # ensure outside clients cannot set a trusted header
+        nginx_reverse_proxy_debug: "{{ 'molecule-notest' in ansible_skip_tags }}"
+        nginx_reverse_proxy_auth_info: |
+          {% if _api_credentials %}
+          {{ [{'name': 'api', 'username': _api_credentials[0], 'password': _api_credentials[1]}] }} 
+          {% else %}
+          {{ omit }}
+          {% endif %}
+        nginx_reverse_proxy_locations: "{{ _expose_api | ternary([_openwebui_vhost, _api_vhost], [_openwebui_vhost]) }}"

--- a/roles/openwebui/defaults/main.yml
+++ b/roles/openwebui/defaults/main.yml
@@ -4,6 +4,8 @@
 openwebui_url: http://localhost:8080
 openwebui_port: 8080
 openwebui_ollama_extra_servers: []
+openwebui_expose_api: false
+openwebui_user_access_api: true
 openwebui_env:
   WEBUI_AUTH_TRUSTED_NAME_HEADER: REMOTE_USER
   WEBUI_AUTH_TRUSTED_EMAIL_HEADER: X-Remote-User-Mail
@@ -12,3 +14,5 @@ openwebui_env:
   DEFAULT_USER_ROLE: admin
   CORS_ALLOW_ORIGIN: "{{ openwebui_url }}"
   USE_CUDA: True
+  ENABLE_API_KEYS: "{{ openwebui_expose_api }}"
+  USER_PERMISSIONS_FEATURES_API_KEYS: "{{ openwebui_user_access_api }}"


### PR DESCRIPTION
This PR allows automatically setting API access options. This prevents users from having to manually grant permissions for the API. Open WebUI has two settings that toggle ability to use the API for admins only, or for normal users as well:

* https://docs.openwebui.com/reference/env-configuration#user_permissions_features_api_keys
* https://docs.openwebui.com/reference/env-configuration#api-key-endpoint-restrictions

This PR sets `ENABLE_API_KEYS` to true if the user requested to expose the API. It also allows normal users to allow the API by default (this can be overriden).